### PR TITLE
Update clarification

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,7 +80,9 @@ To manage Homebridge go to `http://<ip of server>:8581` in your browser. For exa
 
 ## Automated Updates
 
-Automated updates of the Homebridge Docker Image using tools such as Watchtower or similar are strongly discouraged and are done so at your own risk. You can update Homebridge, the Homebridge UI and the Node.js runtime from inside the container.
+Automated updates of the Homebridge Docker Image using tools such as Watchtower or similar are strongly discouraged and are done so at your own risk.
+
+**NOTE** - The version of Homebridge **IS NOT** tied to the version of the container.  You can update Homebridge, the Homebridge UI and the Node.js runtime from inside the container.
 
 ## Troubleshooting
 


### PR DESCRIPTION
## :recycle: Current situation

I missed the note in the README about updating the version of Homebridge in the container, I was expecting that it was done as part of the image.

## :bulb: Proposed solution

I've got a minor suggestion for changing the README a little to clarify updating Homebridge

## :gear: Release Notes

n/a

## :heavy_plus_sign: Additional Information

n/a

### Testing

n/a
